### PR TITLE
Draft transformation of COVID-19 In Vitro Diagnostic Devices and Test Methods Database

### DIFF
--- a/resources/eu_list_transformation.xsl
+++ b/resources/eu_list_transformation.xsl
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="f xsd"
+                version="3.0"
+                xmlns:act="https://covidtesty.vse.cz/vocabulary#"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:f="https://covidtesty.vse.cz/xslt/functions#"
+                xmlns:ncit="http://purl.obolibrary.org/obo/NCIT_"
+                xmlns:qudt="http://qudt.org/schema/qudt/"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+                xmlns:reg="http://purl.org/linked-data/registry#"
+                xmlns:schema="http://schema.org/"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  
+  <!-- Global variables -->
+
+  <xsl:variable name="ns">https://covidtesty.vse.cz/data/</xsl:variable>
+
+  <!-- Functions -->
+  
+  <xsl:import href="functions.xsl"/>
+
+  <!-- Output -->
+
+  <xsl:output encoding="UTF-8" indent="yes" method="xml" normalization-form="NFC"/>
+  <xsl:strip-space elements="*"/>
+
+  <!-- Templates -->
+
+  <xsl:template match="/data">
+    <rdf:RDF>
+      <xsl:apply-templates/>
+    </rdf:RDF>
+  </xsl:template>
+
+  <xsl:template match="deviceList">
+    <xsl:apply-templates mode="device"/>
+  </xsl:template>
+
+  <xsl:template match="*[starts-with(name(), 'device_')]" mode="device">
+    <act:AntigenCovidTest>
+      <xsl:apply-templates/>
+    </act:AntigenCovidTest>
+  </xsl:template>
+
+  <xsl:template match="element_id_device">
+    <xsl:attribute name="rdf:about" select="f:resource-iri('antigen-covid-test', (text()))"/>
+  </xsl:template>
+
+  <xsl:template match="element_commercial_name">
+    <schema:name><xsl:value-of select="text()"/></schema:name>
+  </xsl:template>
+
+  <xsl:template match="manufacturer">
+    <schema:manufacturer>
+      <schema:Organization>
+        <xsl:apply-templates>
+          <xsl:with-param name="manufacturer-id" select="element_id_manufacturer/text()"/>
+        </xsl:apply-templates>
+      </schema:Organization>
+    </schema:manufacturer>
+  </xsl:template>
+
+  <xsl:template match="element_id_manufacturer">
+    <xsl:attribute name="rdf:about" select="f:resource-iri('organization', (text()))"/>
+  </xsl:template>
+
+  <xsl:template match="element_name">
+    <schema:name><xsl:value-of select="text()"/></schema:name>
+  </xsl:template>
+
+  <xsl:template match="element_country">
+    <xsl:param name="manufacturer-id" required="yes"/>
+    <schema:address>
+      <schema:PostalAddress rdf:about="{f:resource-iri('postal-address', ($manufacturer-id))}">
+        <schema:addressCountry><xsl:value-of select="text()"/></schema:addressCountry>
+      </schema:PostalAddress>
+    </schema:address>
+  </xsl:template>
+
+  <xsl:template match="element_website">
+    <schema:url><xsl:value-of select="text()"/></schema:url>
+  </xsl:template>
+
+  <!-- Catch-all empty template -->
+
+  <xsl:template match="text()|@*" mode="#all"/>
+</xsl:stylesheet>

--- a/resources/functions.xsl
+++ b/resources/functions.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet exclude-result-prefixes="f xsd"
+                version="3.0"
+                xmlns:f="https://covidtesty.vse.cz/xslt/functions#"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:function name="f:clean-category" as="xsd:string">
+    <xsl:param name="category" as="xsd:string"/>
+    <xsl:sequence select="replace($category, '2$', '')"/>
+  </xsl:function>
+
+  <!-- Converts camelCase $text into kebab-case. -->
+  <xsl:function name="f:kebab-case" as="xsd:string">
+    <xsl:param name="text" as="xsd:string"/>
+    <xsl:value-of select="f:slugify(replace($text, '(\p{Ll})(\p{Lu})', '$1-$2'))"/>
+  </xsl:function>
+
+  <!-- Mints a new URI in namespace $ns for instance of $class identified with $key. -->
+  <xsl:function name="f:resource-iri" as="xsd:anyURI">
+    <xsl:param name="iri-path" as="xsd:string"/>
+    <xsl:param name="key" as="xsd:string+"/>
+    <xsl:sequence select="concat($ns, $iri-path, '/', string-join(for $k in $key[string-length() != 0] return f:slugify(f:kebab-case($k)), '/')) cast as xsd:anyURI"/>
+  </xsl:function>
+
+  <!-- Converts $text into an IRI-safe slug. -->
+  <xsl:function name="f:slugify" as="xsd:string">
+    <xsl:param name="text" as="xsd:string"/>
+    <xsl:sequence select="encode-for-uri(translate(replace(lower-case(normalize-unicode($text, 'NFKD')), '\P{IsBasicLatin}', ''), ' ', '-'))" />
+  </xsl:function>
+
+</xsl:stylesheet>

--- a/resources/transformation.xsl
+++ b/resources/transformation.xsl
@@ -31,30 +31,8 @@
   <xsl:variable name="dataset" select="concat($ns, 'evaluations')"/>
 
   <!-- Functions -->
-
-  <xsl:function name="f:clean-category" as="xsd:string">
-    <xsl:param name="category" as="xsd:string"/>
-    <xsl:sequence select="replace($category, '2$', '')"/>
-  </xsl:function>
-
-  <!-- Converts camelCase $text into kebab-case. -->
-  <xsl:function name="f:kebab-case" as="xsd:string">
-    <xsl:param name="text" as="xsd:string"/>
-    <xsl:value-of select="f:slugify(replace($text, '(\p{Ll})(\p{Lu})', '$1-$2'))"/>
-  </xsl:function>
-
-  <!-- Mints a new URI in namespace $ns for instance of $class identified with $key. -->
-  <xsl:function name="f:resource-iri" as="xsd:anyURI">
-    <xsl:param name="iri-path" as="xsd:string"/>
-    <xsl:param name="key" as="xsd:string+"/>
-    <xsl:sequence select="concat($ns, $iri-path, '/', string-join(for $k in $key[string-length() != 0] return f:slugify(f:kebab-case($k)), '/')) cast as xsd:anyURI"/>
-  </xsl:function>
-
-  <!-- Converts $text into an IRI-safe slug. -->
-  <xsl:function name="f:slugify" as="xsd:string">
-    <xsl:param name="text" as="xsd:string"/>
-    <xsl:sequence select="encode-for-uri(translate(replace(lower-case(normalize-unicode($text, 'NFKD')), '\P{IsBasicLatin}', ''), ' ', '-'))" />
-  </xsl:function>
+  
+  <xsl:import href="functions.xsl"/>
 
   <!-- Output -->
 

--- a/transform_eu_list.sh
+++ b/transform_eu_list.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+die () {
+  info "$@"
+  exit 1
+}
+
+info () {
+  echo >&2 "$@"
+}
+
+command_available () {
+  COMMAND="${1}"
+  command -v "${COMMAND}" >/dev/null 2>&1 ||
+  die "Please install ${COMMAND}!"
+}
+
+command_available riot
+command_available saxon
+command_available xmllint
+
+FILENAME=covid-19-diagnostics.jrc.ec.europa.eu
+INPUT="${FILENAME}.xml"
+RDFXML="${FILENAME}.rdf"
+
+case "$(uname -sr)" in
+  Darwin*) DAY_AGO=$(date -j -v-1d +%s)
+  ;;
+
+  Linux*) DAY_AGO=$(date --date="1 days ago" +%s)
+  ;;
+esac
+
+# If-Modified-Since HTTP header is not supported, so we download the data
+# if the local file doesn't exist or is older than a day.
+if [[ ! -f "${INPUT}" || $DAY_AGO -ge $(date -r "${INPUT}" +%s) ]]
+then
+  info "Downloading an export."
+
+  curl \
+    --data-urlencode rapid_diag=1 \
+    --data-urlencode search_method=AND \
+    --data-urlencode target_type=6 \
+    --get https://covid-19-diagnostics.jrc.ec.europa.eu/devices/export/xml |
+  xmllint \
+    --format `# Pretty-print XML for readability` \
+    - > "${INPUT}"
+else
+  info "Using a previously downloaded export."
+fi
+
+info "Transforming source XML data to RDF/XML."
+saxon \
+  -s:"${INPUT}" \
+  -xsl:resources/eu_list_transformation.xsl > "${RDFXML}"
+
+info "Validating syntax of the produced RDF/XML."
+riot \
+  --validate \
+  "${RDFXML}"


### PR DESCRIPTION
`./transform_eu_list.sh` vytvoří RDF/XML soubor `covid-19-diagnostics.jrc.ec.europa.eu.rdf`. Pokud ho sloučíme se souborem `data.ttl` vytvořeným pomocí `transform.sh`:

```sh
riot \
  --formatted TURTLE \
  covid-19-diagnostics.jrc.ec.europa.eu.rdf \
  data.ttl \
  resources/vocabulary.ttl > validation_data.ttl
```

Můžeme pak zkusit SHACL validaci:

```sh
shacl validate \
  --data validation_data.ttl \
  --shapes resources/model.ttl
```

Data z COVID-19 In Vitro Diagnostic Devices and Test Methods Database přináší multiplicity v názvech výrobců a jejich webových stránkách.